### PR TITLE
Update to v1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,9 @@
 
 ### Fixed
 
- - Fixed upload to group bug
-
 ### Changed
 
- - Updated 500 error catch message regarding missing group in Bonsai
-
-## [1.3.2-alpha.1]
+## [1.3.2]
 
 ### Added
 
@@ -18,10 +14,12 @@
 
  - Fixed error when no ref genome is provided
  - Fixed `sccmec` bug when comments section is `None`
+ - Fixed upload to group bug
 
 ### Changed
 
  - Added numpy version to `pyproject.toml` dependencies
+ - Updated 500 error catch message regarding missing group in Bonsai
 
 ## [1.3.1]
 

--- a/prp/__version__.py
+++ b/prp/__version__.py
@@ -1,3 +1,3 @@
 """PRP version"""
 
-VERSION = "1.3.2-alpha.1"
+VERSION = "1.3.2"


### PR DESCRIPTION
## [1.3.2]

### Added

### Fixed

 - Fixed error when no ref genome is provided
 - Fixed `sccmec` bug when comments section is `None`
 - Fixed upload to group bug

### Changed

 - Added numpy version to `pyproject.toml` dependencies
 - Updated 500 error catch message regarding missing group in Bonsai
